### PR TITLE
Fix session creation error - Add is_connected column to quiz_participants

### DIFF
--- a/database/migrations/001_create_quiz_tables.sql
+++ b/database/migrations/001_create_quiz_tables.sql
@@ -19,6 +19,7 @@ CREATE TABLE quiz_participants (
   display_name VARCHAR(50) NOT NULL,
   score INTEGER DEFAULT 0,
   is_eliminated BOOLEAN DEFAULT FALSE,
+  is_connected BOOLEAN DEFAULT TRUE,
   joined_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 


### PR DESCRIPTION
## Summary
- Fixed missing `is_connected` column in `quiz_participants` table schema
- This column was expected by the host page to track participant connection status
- Resolves session creation 500 error by ensuring database schema matches application expectations

## Test plan
- [x] Deploy database migration
- [x] Test session creation functionality
- [x] Verify host page displays participant connection status correctly

🤖 Generated with [Claude Code](https://claude.ai/code)