### PR TITLE
fix: サーバーサイド認証の修正でセッション参加エラーを解決

### DIFF
--- a/app/api/quiz/sessions/[id]/join/route.ts
+++ b/app/api/quiz/sessions/[id]/join/route.ts
@@ -1,7 +1,7 @@
 // セッション参加API
 
 import { NextRequest, NextResponse } from 'next/server';
-import { ParticipantService } from '@/app/lib/supabase/participants';
+import { ParticipantServerService } from '@/app/lib/supabase/participants-server';
 
 export async function POST(
   request: NextRequest,
@@ -27,7 +27,7 @@ export async function POST(
       );
     }
 
-    const participantService = new ParticipantService();
+    const participantService = new ParticipantServerService();
     const result = await participantService.joinSession(sessionId, displayName.trim());
 
     return NextResponse.json(result);
@@ -55,7 +55,7 @@ export async function DELETE(
   try {
     const { id: sessionId } = await context.params;
 
-    const participantService = new ParticipantService();
+    const participantService = new ParticipantServerService();
     await participantService.leaveSession(sessionId);
 
     return NextResponse.json({ success: true });

--- a/app/api/quiz/sessions/[id]/route.ts
+++ b/app/api/quiz/sessions/[id]/route.ts
@@ -2,8 +2,8 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { QuizSessionService } from '@/app/lib/supabase/quiz-sessions';
-import { ParticipantService } from '@/app/lib/supabase/participants';
-import { createClient } from '@/app/lib/supabase/client';
+import { ParticipantServerService } from '@/app/lib/supabase/participants-server';
+import { createClient } from '@/app/lib/supabase/server';
 
 export async function GET(
   request: NextRequest,
@@ -13,7 +13,7 @@ export async function GET(
     const { id: sessionId } = await context.params;
     
     const sessionService = new QuizSessionService();
-    const participantService = new ParticipantService();
+    const participantService = new ParticipantServerService();
     
     // セッション情報取得
     const session = await sessionService.getSession(sessionId);
@@ -28,7 +28,7 @@ export async function GET(
     const participants = await participantService.getParticipants(sessionId);
 
     // 問題一覧取得
-    const supabase = createClient();
+    const supabase = await createClient();
     const { data: questions, error: questionsError } = await supabase
       .from('quiz_questions')
       .select('*')

--- a/app/lib/supabase/participants-server.ts
+++ b/app/lib/supabase/participants-server.ts
@@ -1,0 +1,151 @@
+// サーバーサイド用クイズ参加者関連のデータベース操作
+
+import { createClient } from '@/app/lib/supabase/server';
+import type { QuizParticipant, JoinSessionResponse } from '@/app/types/quiz';
+
+export class ParticipantServerService {
+  /**
+   * セッションに参加
+   */
+  async joinSession(
+    sessionId: string,
+    displayName: string
+  ): Promise<JoinSessionResponse> {
+    const supabase = await createClient();
+    
+    // 現在のセッションとユーザー取得
+    const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+    if (sessionError) {
+      console.error('Session error:', sessionError);
+      throw new Error(`認証エラー: ${sessionError.message}`);
+    }
+    if (!session || !session.user) {
+      console.error('No session or user found');
+      throw new Error('ログインセッションが見つかりません。再度ログインしてください。');
+    }
+    const user = session.user;
+
+    // 既に参加しているかチェック
+    const { data: existingParticipant } = await supabase
+      .from('quiz_participants')
+      .select('*')
+      .eq('room_id', sessionId)
+      .eq('user_id', user.id)
+      .single();
+
+    if (existingParticipant) {
+      throw new Error('既にこのセッションに参加しています');
+    }
+
+    // クイズルーム情報を取得して参加人数制限をチェック
+    const { data: quizRoom, error: roomError } = await supabase
+      .from('quiz_rooms')
+      .select('*, quiz_participants(count)')
+      .eq('id', sessionId)
+      .single();
+
+    if (roomError) {
+      throw new Error('セッションが見つかりません');
+    }
+
+    if (quizRoom.status !== 'waiting') {
+      throw new Error('このセッションは既に開始されています');
+    }
+
+    const currentParticipants = Array.isArray(quizRoom.quiz_participants) 
+      ? quizRoom.quiz_participants.length 
+      : quizRoom.quiz_participants?.count || 0;
+
+    if (currentParticipants >= quizRoom.max_players) {
+      throw new Error('参加人数が上限に達しています');
+    }
+
+    // 参加者を追加
+    const { data: participant, error } = await supabase
+      .from('quiz_participants')
+      .insert({
+        room_id: sessionId,
+        user_id: user.id,
+        display_name: displayName
+      })
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error('参加に失敗しました: ' + error.message);
+    }
+
+    return {
+      participant: participant as QuizParticipant,
+      session: quizRoom as any // TODO: 型を修正
+    };
+  }
+
+  /**
+   * セッションから退出
+   */
+  async leaveSession(sessionId: string): Promise<void> {
+    const supabase = await createClient();
+    const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+    if (sessionError || !session || !session.user) {
+      throw new Error('ログインセッションが必要です');
+    }
+    const user = session.user;
+
+    const { error } = await supabase
+      .from('quiz_participants')
+      .delete()
+      .eq('room_id', sessionId)
+      .eq('user_id', user.id);
+
+    if (error) {
+      throw new Error('退出に失敗しました: ' + error.message);
+    }
+  }
+
+  /**
+   * セッションの参加者一覧を取得
+   */
+  async getParticipants(sessionId: string): Promise<QuizParticipant[]> {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from('quiz_participants')
+      .select('*')
+      .eq('room_id', sessionId)
+      .order('joined_at', { ascending: true });
+
+    if (error) {
+      throw new Error('参加者一覧取得に失敗しました: ' + error.message);
+    }
+
+    return data as QuizParticipant[];
+  }
+
+  /**
+   * 現在のユーザーの参加状況を取得
+   */
+  async getCurrentUserParticipation(sessionId: string): Promise<QuizParticipant | null> {
+    const supabase = await createClient();
+    const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+    if (sessionError || !session || !session.user) {
+      return null;
+    }
+    const user = session.user;
+
+    const { data, error } = await supabase
+      .from('quiz_participants')
+      .select('*')
+      .eq('room_id', sessionId)
+      .eq('user_id', user.id)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return null;
+      }
+      throw new Error('参加状況取得に失敗しました: ' + error.message);
+    }
+
+    return data as QuizParticipant;
+  }
+}


### PR DESCRIPTION
## 概要
「ログインセッションが見つかりません」エラーを修正しました。

## 問題
- APIルートでクライアントサイドの`createClient()`を使用していたため、サーバーサイドで認証情報が正しく取得できていませんでした
- セッション作成は成功するが、参加時にログインエラーが発生していました

## 修正内容
1. サーバーサイド専用の`ParticipantServerService`を作成
2. APIルートで以下の変更を実施：
   - `createClient`を`@/app/lib/supabase/server`からインポート
   - `ParticipantService`を`ParticipantServerService`に変更
   - `createClient()`を`await createClient()`に変更（サーバー版は非同期）

## テスト方法
1. ログイン後、クイズルームを作成
2. ルームコードを使って参加を試みる
3. 「ログインセッションが見つかりません」エラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)