### PR TITLE
Fix quiz session join issues with room code search and database schema

### DIFF
--- a/app/api/quiz/sessions/[id]/route.ts
+++ b/app/api/quiz/sessions/[id]/route.ts
@@ -32,7 +32,7 @@ export async function GET(
     const { data: questions, error: questionsError } = await supabase
       .from('quiz_questions')
       .select('*')
-      .eq('room_id', sessionId)
+      .eq('session_id', sessionId)
       .order('question_order');
 
     if (questionsError) {

--- a/app/api/quiz/sessions/route.ts
+++ b/app/api/quiz/sessions/route.ts
@@ -1,7 +1,7 @@
 // クイズセッション作成API
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/app/lib/supabase/api';
+import { createClient } from '@/app/lib/supabase/server';
 import type { QuizSettings } from '@/app/types/quiz';
 
 export async function POST(request: NextRequest) {
@@ -137,6 +137,8 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient();
+    const { searchParams } = new URL(request.url);
+    const roomCode = searchParams.get('roomCode');
     
     // 認証チェック
     const { data: { user }, error: userError } = await supabase.auth.getUser();
@@ -145,6 +147,32 @@ export async function GET(request: NextRequest) {
         { error: 'ログインが必要です' },
         { status: 401 }
       );
+    }
+
+    // ルームコード検索の場合
+    if (roomCode) {
+      const { data: session, error } = await supabase
+        .from('quiz_sessions')
+        .select('id, room_code, status, settings, created_at')
+        .eq('room_code', roomCode.toUpperCase())
+        .single();
+
+      if (error) {
+        console.error('Room code search error:', error);
+        return NextResponse.json(
+          { error: 'セッションが見つかりません' },
+          { status: 404 }
+        );
+      }
+
+      if (!session) {
+        return NextResponse.json(
+          { error: 'セッションが見つかりません' },
+          { status: 404 }
+        );
+      }
+
+      return NextResponse.json({ sessionId: session.id, session });
     }
 
     // ホストしているセッション一覧取得


### PR DESCRIPTION
## Summary
- Fix sessionId undefined error when joining quiz sessions by adding room code search functionality
- Create server-side ParticipantServerService for proper authentication in API routes
- Fix database field name mismatches (room_id -> session_id)
- Update all session-related API routes to use server-side Supabase client

## Changes Made
- Added room code search to `/api/quiz/sessions` GET endpoint to handle `?roomCode=${code}` queries
- Created `ParticipantServerService` with server-side authentication for API routes
- Fixed database table and field references throughout the codebase:
  - `room_id` → `session_id` in quiz_participants queries
  - Proper `session_id` references in quiz_questions
- Updated import statements to use server-side Supabase client
- Fixed participant limit validation using `settings.maxParticipants`

## Test Plan
- [ ] Test room code lookup functionality
- [ ] Test quiz session join with valid room code
- [ ] Test authentication error handling
- [ ] Test participant limit validation
- [ ] Verify session data retrieval works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)