### PR TITLE
Fix database field references to use room_id instead of session_id

### DIFF
--- a/app/api/quiz/sessions/[id]/route.ts
+++ b/app/api/quiz/sessions/[id]/route.ts
@@ -32,7 +32,7 @@ export async function GET(
     const { data: questions, error: questionsError } = await supabase
       .from('quiz_questions')
       .select('*')
-      .eq('session_id', sessionId)
+      .eq('room_id', sessionId)
       .order('question_order');
 
     if (questionsError) {

--- a/app/lib/supabase/participants-server.ts
+++ b/app/lib/supabase/participants-server.ts
@@ -29,7 +29,7 @@ export class ParticipantServerService {
     const { data: existingParticipant } = await supabase
       .from('quiz_participants')
       .select('*')
-      .eq('session_id', sessionId)
+      .eq('room_id', sessionId)
       .eq('user_id', user.id)
       .single();
 
@@ -56,7 +56,7 @@ export class ParticipantServerService {
     const { count: currentParticipants, error: countError } = await supabase
       .from('quiz_participants')
       .select('*', { count: 'exact', head: true })
-      .eq('session_id', sessionId);
+      .eq('room_id', sessionId);
 
     if (countError) {
       console.error('Participant count error:', countError);
@@ -71,7 +71,7 @@ export class ParticipantServerService {
     const { data: participant, error } = await supabase
       .from('quiz_participants')
       .insert({
-        session_id: sessionId,
+        room_id: sessionId,
         user_id: user.id,
         display_name: displayName
       })
@@ -102,7 +102,7 @@ export class ParticipantServerService {
     const { error } = await supabase
       .from('quiz_participants')
       .delete()
-      .eq('session_id', sessionId)
+      .eq('room_id', sessionId)
       .eq('user_id', user.id);
 
     if (error) {
@@ -118,7 +118,7 @@ export class ParticipantServerService {
     const { data, error } = await supabase
       .from('quiz_participants')
       .select('*')
-      .eq('session_id', sessionId)
+      .eq('room_id', sessionId)
       .order('joined_at', { ascending: true });
 
     if (error) {
@@ -142,7 +142,7 @@ export class ParticipantServerService {
     const { data, error } = await supabase
       .from('quiz_participants')
       .select('*')
-      .eq('session_id', sessionId)
+      .eq('room_id', sessionId)
       .eq('user_id', user.id)
       .single();
 


### PR DESCRIPTION
## Summary
- Fix ParticipantServerService to use `room_id` column instead of `session_id`
- Update quiz_questions query to use correct `room_id` field
- Resolves the "null value in column room_id violates not-null constraint" error

## Problem
The actual database schema has both `room_id` and `session_id` columns in `quiz_participants`:
- `room_id`: NOT NULL constraint (actively used)
- `session_id`: nullable (exists but not the primary field)

The code was trying to insert into `session_id` while leaving `room_id` null, causing the constraint violation.

## Changes
- Updated all `quiz_participants` queries to use `room_id` instead of `session_id`
- Fixed quiz_questions query to use `room_id` field
- Maintains compatibility with actual database structure

## Test Plan
- [ ] Test quiz session join functionality
- [ ] Verify participants are properly added with room_id
- [ ] Confirm no database constraint violations

🤖 Generated with [Claude Code](https://claude.ai/code)