### PR TITLE
Fix RLS policies and session creation issues

### DIFF
--- a/database/migrations/005_fix_rls_simple.sql
+++ b/database/migrations/005_fix_rls_simple.sql
@@ -1,0 +1,93 @@
+-- 段階的にRLSポリシーを修正
+
+-- quiz_sessionsテーブルのSELECTポリシーを修正
+DROP POLICY IF EXISTS "Users can view quiz sessions they participate in" ON quiz_sessions;
+
+CREATE POLICY "Users can view quiz sessions they participate in" ON quiz_sessions
+  FOR SELECT USING (
+    host_user_id = auth.uid() OR 
+    id IN (SELECT room_id FROM quiz_participants WHERE user_id = auth.uid())
+  );
+
+-- quiz_participantsテーブルのポリシーを修正
+DROP POLICY IF EXISTS "Users can view participants in their sessions" ON quiz_participants;
+
+CREATE POLICY "Users can view participants in their sessions" ON quiz_participants
+  FOR SELECT USING (
+    room_id IN (
+      SELECT id FROM quiz_sessions 
+      WHERE host_user_id = auth.uid() OR 
+            id IN (SELECT room_id FROM quiz_participants WHERE user_id = auth.uid())
+    )
+  );
+
+-- get_session_stats関数を修正してroom_idを使用
+CREATE OR REPLACE FUNCTION get_session_stats(p_session_id UUID)
+RETURNS JSON AS $$
+DECLARE
+    result JSON;
+BEGIN
+    SELECT json_build_object(
+        'total_participants', COUNT(*),
+        'total_questions', (SELECT COUNT(*) FROM quiz_questions WHERE room_id = p_session_id),
+        'current_question', (SELECT current_question_index FROM quiz_sessions WHERE id = p_session_id),
+        'leaderboard', (
+            SELECT json_agg(
+                json_build_object(
+                    'participant_id', id,
+                    'display_name', display_name,
+                    'score', score,
+                    'rank', ROW_NUMBER() OVER (ORDER BY score DESC)
+                )
+            ) 
+            FROM quiz_participants 
+            WHERE room_id = p_session_id 
+            ORDER BY score DESC
+        )
+    ) INTO result
+    FROM quiz_participants
+    WHERE room_id = p_session_id;
+    
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql;
+
+-- generate_room_code関数を修正してRLSの影響を受けないようにする
+CREATE OR REPLACE FUNCTION generate_room_code()
+RETURNS TEXT 
+LANGUAGE plpgsql
+SECURITY DEFINER  -- この関数は定義者の権限で実行される
+AS $$
+DECLARE
+    chars TEXT := 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    result TEXT := '';
+    i INTEGER;
+BEGIN
+    FOR i IN 1..6 LOOP
+        result := result || substr(chars, floor(random() * length(chars) + 1)::INTEGER, 1);
+    END LOOP;
+    
+    -- 重複チェック（SECURITY DEFINERでRLSを回避）
+    WHILE EXISTS(SELECT 1 FROM quiz_sessions WHERE room_code = result) LOOP
+        result := '';
+        FOR i IN 1..6 LOOP
+            result := result || substr(chars, floor(random() * length(chars) + 1)::INTEGER, 1);
+        END LOOP;
+    END LOOP;
+    
+    RETURN result;
+END;
+$$;
+
+-- リアルタイム機能を確実に有効化
+DO $$
+BEGIN
+    -- quiz_participantsテーブルをリアルタイム対象に追加
+    BEGIN
+        ALTER PUBLICATION supabase_realtime ADD TABLE quiz_participants;
+    EXCEPTION
+        WHEN duplicate_object THEN 
+            -- 既に追加済みの場合は何もしない
+            NULL;
+    END;
+END $$;


### PR DESCRIPTION
## Summary
- Fix RLS policies to match actual database schema (room_id vs session_id)
- Resolve session creation failures
- Enable realtime participant updates for hosts

## Database Issues Fixed
1. **Session Creation Error**: `quiz_sessions` SELECT policy was referencing non-existent `session_id` column
2. **generate_room_code Function**: RLS was blocking room code duplicate checks
3. **Participant Visibility**: RLS policies prevented hosts from seeing participants in realtime
4. **Function Consistency**: `get_session_stats` was using inconsistent field references

## Changes Made
- **RLS Policy Updates**: Changed `session_id` references to `room_id` to match actual schema
- **Security Enhancement**: Added `SECURITY DEFINER` to `generate_room_code` function
- **Function Fixes**: Updated `get_session_stats` to use `room_id` consistently
- **Realtime Setup**: Ensured `quiz_participants` table is included in realtime publication

## Migration: 005_fix_rls_simple.sql
```sql
-- Key fixes:
- quiz_sessions SELECT policy: session_id → room_id
- quiz_participants RLS policy: proper room_id references
- generate_room_code: SECURITY DEFINER for RLS bypass
- get_session_stats: consistent room_id usage
- Realtime publication: quiz_participants included
```

## Expected Fixes
- ✅ "セッション作成に失敗しました" error resolved
- ✅ Host can see participants join in realtime
- ✅ RLS policies match actual database structure

## Test Plan
- [ ] Test quiz session creation
- [ ] Verify participant joining shows up for host immediately
- [ ] Confirm RLS policies don't block legitimate access

🤖 Generated with [Claude Code](https://claude.ai/code)