### PR TITLE
Add debugging for session creation failure

### DIFF
--- a/app/api/test/rpc/route.ts
+++ b/app/api/test/rpc/route.ts
@@ -1,0 +1,37 @@
+// RPC関数テスト用のエンドポイント（デバッグ用）
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/app/lib/supabase/server';
+
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    
+    console.log('Testing generate_room_code function...');
+    const { data, error } = await supabase.rpc('generate_room_code');
+    
+    console.log('RPC result:', { data, error });
+    
+    if (error) {
+      return NextResponse.json({
+        success: false,
+        error: error.message,
+        details: error,
+        step: 'rpc_test'
+      });
+    }
+    
+    return NextResponse.json({
+      success: true,
+      roomCode: data,
+      message: 'generate_room_code function is working'
+    });
+  } catch (err) {
+    console.error('Test RPC error:', err);
+    return NextResponse.json({
+      success: false,
+      error: err instanceof Error ? err.message : 'Unknown error',
+      step: 'test_catch'
+    });
+  }
+}


### PR DESCRIPTION
## Summary
Add detailed debugging to identify where session creation is failing

## Changes
- Enhanced error logging for room code generation with try-catch
- Added session creation parameter logging
- Created test endpoint `/api/test/rpc` to verify RPC function availability  
- Improved error responses with step identification (`room_code_generation`, `session_creation`, etc.)

## Debug Endpoints
- `/api/test/rpc` - Test if `generate_room_code` function exists and works

## Expected Results
This will help identify exactly where the "セッション作成に失敗しました" error occurs:
1. Authentication step
2. Playlist validation step  
3. Room code generation step
4. Session creation step

## Test Plan
- [ ] Access `/api/test/rpc` to verify RPC function
- [ ] Check browser console/network tab during session creation
- [ ] Identify which step fails with detailed error messages

🤖 Generated with [Claude Code](https://claude.ai/code)