### PR TITLE
Temporarily disable RLS to fix session creation

### DIFF
--- a/database/migrations/007_fix_sessions_rls.sql
+++ b/database/migrations/007_fix_sessions_rls.sql
@@ -1,0 +1,15 @@
+-- quiz_sessionsのRLSを一時的に無効化してテスト
+
+-- 全てのRLSポリシーを削除
+DROP POLICY IF EXISTS "Users can view quiz sessions they participate in" ON quiz_sessions;
+DROP POLICY IF EXISTS "Users can create quiz sessions" ON quiz_sessions;
+DROP POLICY IF EXISTS "Session hosts can update their sessions" ON quiz_sessions;
+
+-- RLSを無効化
+ALTER TABLE quiz_sessions DISABLE ROW LEVEL SECURITY;
+
+-- quiz_participantsも同様に一時的に無効化
+DROP POLICY IF EXISTS "Users can view participants in their sessions" ON quiz_participants;
+DROP POLICY IF EXISTS "Users can join sessions" ON quiz_participants;
+
+ALTER TABLE quiz_participants DISABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Problem
Still getting infinite recursion errors in quiz_sessions policy:
```
infinite recursion detected in policy for relation "quiz_sessions"
```

## Temporary Solution
Disable RLS entirely on the problematic tables to get basic functionality working:
- `quiz_sessions` - RLS disabled
- `quiz_participants` - RLS disabled

## Migration: 007_fix_sessions_rls.sql
- Removes all RLS policies
- Disables ROW LEVEL SECURITY on both tables
- Temporary fix to unblock development

## Next Steps (Future)
1. Get session creation/joining working
2. Test realtime participant updates
3. Re-enable RLS with proper non-recursive policies
4. Implement application-level security controls

## Security Note
This temporarily removes database-level access control. Should only be used in development environment.

🤖 Generated with [Claude Code](https://claude.ai/code)