### PR TITLE
Fix host not showing in participant list

### DIFF
--- a/app/api/quiz/sessions/route.ts
+++ b/app/api/quiz/sessions/route.ts
@@ -137,6 +137,26 @@ export async function POST(request: NextRequest) {
 
     console.log('Session created:', data);
 
+    // ホストを自動的に参加者として登録
+    try {
+      const { error: participantError } = await supabase
+        .from('quiz_participants')
+        .insert({
+          room_id: data.id,
+          user_id: user.id,
+          display_name: user.email?.split('@')[0] || 'Host' // メールアドレスの@より前をデフォルト名に
+        });
+
+      if (participantError) {
+        console.error('Failed to add host as participant:', participantError);
+        // エラーでもセッション作成は成功とする
+      } else {
+        console.log('Host added as participant');
+      }
+    } catch (participantErr) {
+      console.error('Error adding host as participant:', participantErr);
+    }
+
     return NextResponse.json({
       sessionId: data.id,
       roomCode: data.room_code

--- a/app/quiz/room/[id]/page.tsx
+++ b/app/quiz/room/[id]/page.tsx
@@ -92,14 +92,25 @@ export default function QuizRoomPage({ params }: { params: Promise<{ id: string 
   }
 
   const loadParticipants = async () => {
+    console.log('Loading participants for room:', roomId)
     const supabase = createClient()
-    const { data } = await supabase
+    const { data, error } = await supabase
       .from('quiz_participants')
       .select('*')
       .eq('room_id', roomId)
 
+    console.log('Participants query result:', { data, error, roomId })
+    
+    if (error) {
+      console.error('Error loading participants:', error)
+    }
+    
     if (data) {
+      console.log('Setting participants:', data)
       setParticipants(data as any)
+    } else {
+      console.log('No participant data received')
+      setParticipants([])
     }
   }
 


### PR DESCRIPTION
## Problem
Host shows "参加者 (0人)" instead of showing themselves in the participant list.

## Root Cause
- Host was not automatically added as a participant when creating a session
- `loadParticipants` function was not properly loading/displaying participants

## Solution
1. **Auto-add Host**: When session is created, automatically add host as participant
2. **Enhanced Logging**: Add detailed logging to `loadParticipants` function
3. **Error Handling**: Proper error handling for participant queries

## Changes
- Session creation now auto-adds host with email prefix as display name
- `loadParticipants` logs query results for debugging
- Participant loading errors are properly logged

## Expected Fix
- ✅ Host should see themselves in participant list (1人)
- ✅ Other participants joining should increment count (2人, 3人...)
- ✅ Realtime updates should work once basic loading works

## Test Plan
1. Create new session
2. Check console logs for participant loading
3. Verify host shows in participant list
4. Test participant joining from another browser

🤖 Generated with [Claude Code](https://claude.ai/code)