### PR TITLE
Fix participant display by using correct database column

### DIFF
--- a/app/quiz/room/[id]/page.tsx
+++ b/app/quiz/room/[id]/page.tsx
@@ -115,7 +115,7 @@ export default function QuizRoomPage({ params }: { params: Promise<{ id: string 
     const { data, error } = await supabase
       .from('quiz_participants')
       .select('*')
-      .eq('room_id', roomId)
+      .eq('session_id', roomId)
 
     console.log('Participants query result:', { data, error, roomId })
     
@@ -146,7 +146,7 @@ export default function QuizRoomPage({ params }: { params: Promise<{ id: string 
           event: '*',
           schema: 'public',
           table: 'quiz_participants',
-          filter: `room_id=eq.${roomId}`,
+          filter: `session_id=eq.${roomId}`,
         },
         (payload) => {
           console.log('Realtime participant change:', payload)


### PR DESCRIPTION
## Summary
- Fixed participant loading issue where host view showed "参加者 (0人)" despite participants being in the room
- Changed database queries from `room_id` to `session_id` to match actual database schema
- Updated both the loadParticipants function and realtime subscription filter

## Root Cause
The quiz_participants table uses `session_id` to reference quiz_sessions, but the code was incorrectly using `room_id` column which doesn't match the foreign key relationship.

## Test Plan
- [x] Verify participants now appear in host view
- [x] Test realtime updates when participants join/leave
- [x] Confirm debug logs now show participant data

🤖 Generated with [Claude Code](https://claude.ai/code)