### PR TITLE
Fix participant display: use session_id consistently

### DIFF
--- a/app/api/quiz/questions/generate/route.ts
+++ b/app/api/quiz/questions/generate/route.ts
@@ -93,7 +93,7 @@ export async function POST(request: NextRequest) {
     const { error: deleteError } = await supabase
       .from('quiz_questions')
       .delete()
-      .eq('room_id', sessionId);
+      .eq('session_id', sessionId);
 
     if (deleteError) {
       console.error('Existing questions deletion error:', deleteError);

--- a/app/api/quiz/sessions/[id]/route.ts
+++ b/app/api/quiz/sessions/[id]/route.ts
@@ -32,7 +32,7 @@ export async function GET(
     const { data: questions, error: questionsError } = await supabase
       .from('quiz_questions')
       .select('*')
-      .eq('room_id', sessionId)
+      .eq('session_id', sessionId)
       .order('question_order');
 
     if (questionsError) {

--- a/app/api/quiz/sessions/[id]/start/route.ts
+++ b/app/api/quiz/sessions/[id]/start/route.ts
@@ -50,7 +50,7 @@ export async function POST(
     const { data: questions, error: questionsError } = await supabase
       .from('quiz_questions')
       .select('id')
-      .eq('room_id', sessionId);
+      .eq('session_id', sessionId);
 
     if (questionsError) {
       throw new Error('問題取得に失敗しました');
@@ -67,7 +67,7 @@ export async function POST(
     const { data: participants, error: participantsError } = await supabase
       .from('quiz_participants')
       .select('id')
-      .eq('room_id', sessionId);
+      .eq('session_id', sessionId);
 
     if (participantsError) {
       throw new Error('参加者取得に失敗しました');

--- a/app/lib/supabase/participants-server.ts
+++ b/app/lib/supabase/participants-server.ts
@@ -29,7 +29,7 @@ export class ParticipantServerService {
     const { data: existingParticipant } = await supabase
       .from('quiz_participants')
       .select('*')
-      .eq('room_id', sessionId)
+      .eq('session_id', sessionId)
       .eq('user_id', user.id)
       .single();
 
@@ -56,7 +56,7 @@ export class ParticipantServerService {
     const { count: currentParticipants, error: countError } = await supabase
       .from('quiz_participants')
       .select('*', { count: 'exact', head: true })
-      .eq('room_id', sessionId);
+      .eq('session_id', sessionId);
 
     if (countError) {
       console.error('Participant count error:', countError);
@@ -71,7 +71,7 @@ export class ParticipantServerService {
     const { data: participant, error } = await supabase
       .from('quiz_participants')
       .insert({
-        room_id: sessionId,
+        session_id: sessionId,
         user_id: user.id,
         display_name: displayName
       })
@@ -102,7 +102,7 @@ export class ParticipantServerService {
     const { error } = await supabase
       .from('quiz_participants')
       .delete()
-      .eq('room_id', sessionId)
+      .eq('session_id', sessionId)
       .eq('user_id', user.id);
 
     if (error) {
@@ -118,7 +118,7 @@ export class ParticipantServerService {
     const { data, error } = await supabase
       .from('quiz_participants')
       .select('*')
-      .eq('room_id', sessionId)
+      .eq('session_id', sessionId)
       .order('joined_at', { ascending: true });
 
     if (error) {
@@ -142,7 +142,7 @@ export class ParticipantServerService {
     const { data, error } = await supabase
       .from('quiz_participants')
       .select('*')
-      .eq('room_id', sessionId)
+      .eq('session_id', sessionId)
       .eq('user_id', user.id)
       .single();
 

--- a/app/lib/supabase/participants.ts
+++ b/app/lib/supabase/participants.ts
@@ -35,7 +35,7 @@ export class ParticipantService {
     const { data: existingParticipant } = await this.supabase
       .from('quiz_participants')
       .select('*')
-      .eq('room_id', sessionId)
+      .eq('session_id', sessionId)
       .eq('user_id', user.id)
       .single();
 
@@ -70,7 +70,7 @@ export class ParticipantService {
     const { data: participant, error } = await this.supabase
       .from('quiz_participants')
       .insert({
-        room_id: sessionId,
+        session_id: sessionId,
         user_id: user.id,
         display_name: displayName
       })
@@ -100,7 +100,7 @@ export class ParticipantService {
     const { error } = await this.supabase
       .from('quiz_participants')
       .delete()
-      .eq('room_id', sessionId)
+      .eq('session_id', sessionId)
       .eq('user_id', user.id);
 
     if (error) {
@@ -115,7 +115,7 @@ export class ParticipantService {
     const { data, error } = await this.supabase
       .from('quiz_participants')
       .select('*')
-      .eq('room_id', sessionId)
+      .eq('session_id', sessionId)
       .order('joined_at', { ascending: true });
 
     if (error) {
@@ -181,7 +181,7 @@ export class ParticipantService {
     const { data, error } = await this.supabase
       .from('quiz_participants')
       .select('*')
-      .eq('room_id', sessionId)
+      .eq('session_id', sessionId)
       .eq('user_id', user.id)
       .single();
 


### PR DESCRIPTION
## Summary
- Fixed the participant display issue in host view
- Updated all database operations to use `session_id` consistently instead of mixing `room_id` and `session_id`
- This ensures participants show up correctly in the host dashboard

## Problem Solved
The host view was showing 0 participants because:
1. Participant services were inserting data with `room_id` populated
2. Host queries were filtering by `session_id` 
3. Database column mismatch caused empty results

## Changes Made
✅ `app/lib/supabase/participants.ts` - All operations use `session_id`
✅ `app/lib/supabase/participants-server.ts` - All operations use `session_id`
✅ `app/api/quiz/questions/generate/route.ts` - Question queries use `session_id` 
✅ `app/api/quiz/sessions/[id]/route.ts` - Session queries use `session_id`
✅ `app/api/quiz/sessions/[id]/start/route.ts` - Participant checks use `session_id`

## Test Results
- ✅ Participants now display correctly in host view
- ✅ Real-time participant updates work
- ✅ Database queries are consistent

🤖 Generated with [Claude Code](https://claude.ai/code)