### PR TITLE
Fix NOT NULL constraint error in participant creation

### DIFF
--- a/app/lib/supabase/participants-server.ts
+++ b/app/lib/supabase/participants-server.ts
@@ -72,6 +72,7 @@ export class ParticipantServerService {
       .from('quiz_participants')
       .insert({
         session_id: sessionId,
+        room_id: sessionId,  // room_idも同じ値を設定（NOT NULL制約対応）
         user_id: user.id,
         display_name: displayName
       })

--- a/app/lib/supabase/participants.ts
+++ b/app/lib/supabase/participants.ts
@@ -71,6 +71,7 @@ export class ParticipantService {
       .from('quiz_participants')
       .insert({
         session_id: sessionId,
+        room_id: sessionId,  // room_idも同じ値を設定（NOT NULL制約対応）
         user_id: user.id,
         display_name: displayName
       })


### PR DESCRIPTION
## Problem
Participants were unable to join quiz rooms due to a database constraint error:
```
参加に失敗しました: null value in column "room_id" of relation "quiz_participants" violates not-null constraint
```

## Root Cause
The participant insertion code was only setting `session_id` but the database schema requires `room_id` to be non-null as well.

## Solution
✅ Set both `session_id` and `room_id` to the same `sessionId` value during participant creation
✅ Maintains compatibility with existing query logic that uses `session_id`
✅ Satisfies the database NOT NULL constraint for `room_id`
✅ Applied to both client and server participant services

## Changes Made
- `app/lib/supabase/participants.ts`: Added `room_id: sessionId` to insert statement
- `app/lib/supabase/participants-server.ts`: Added `room_id: sessionId` to insert statement

## Code Changes
```typescript
// Before
.insert({
  session_id: sessionId,
  user_id: user.id,
  display_name: displayName
})

// After  
.insert({
  session_id: sessionId,
  room_id: sessionId,  // Added to satisfy NOT NULL constraint
  user_id: user.id,
  display_name: displayName
})
```

## Test Results
- ✅ Participants can now join rooms without constraint errors
- ✅ Host view displays participants correctly
- ✅ Auto-migration system works for existing data
- ✅ New participants are stored with consistent data

## Benefits
🚀 **Fixed Join Error**: Participants can successfully join quiz rooms
🔧 **Data Consistency**: Both columns populated with correct session ID
🛡️ **Database Compliance**: Satisfies all NOT NULL constraints
⚡ **Backward Compatible**: Existing queries continue to work

🤖 Generated with [Claude Code](https://claude.ai/code)