### PR TITLE
Fix quiz start error: use correct table name quiz_sessions

### DIFF
--- a/app/lib/supabase/quiz-sessions.ts
+++ b/app/lib/supabase/quiz-sessions.ts
@@ -50,9 +50,9 @@ export class QuizSessionService {
       userId = session.user.id;
     }
 
-    // セッション作成（既存quiz_roomsテーブルを使用）
+    // セッション作成（quiz_sessionsテーブルを使用）
     const { data, error } = await this.supabase
-      .from('quiz_rooms')
+      .from('quiz_sessions')
       .insert({
         playlist_id: playlistId,
         room_code: roomCodeData,
@@ -78,7 +78,7 @@ export class QuizSessionService {
    */
   async getSession(sessionId: string): Promise<QuizSession | null> {
     const { data, error } = await this.supabase
-      .from('quiz_rooms')
+      .from('quiz_sessions')
       .select('*')
       .eq('id', sessionId)
       .single();
@@ -98,7 +98,7 @@ export class QuizSessionService {
    */
   async getSessionByRoomCode(roomCode: string): Promise<QuizSession | null> {
     const { data, error } = await this.supabase
-      .from('quiz_rooms')
+      .from('quiz_sessions')
       .select('*')
       .eq('room_code', roomCode.toUpperCase())
       .single();
@@ -121,7 +121,7 @@ export class QuizSessionService {
     status: 'waiting' | 'playing' | 'finished'
   ): Promise<void> {
     const { error } = await this.supabase
-      .from('quiz_rooms')
+      .from('quiz_sessions')
       .update({ status })
       .eq('id', sessionId);
 
@@ -138,7 +138,7 @@ export class QuizSessionService {
     questionIndex: number
   ): Promise<void> {
     const { error } = await this.supabase
-      .from('quiz_rooms')
+      .from('quiz_sessions')
       .update({ current_question_index: questionIndex })
       .eq('id', sessionId);
 
@@ -152,7 +152,7 @@ export class QuizSessionService {
    */
   async deleteSession(sessionId: string): Promise<void> {
     const { error } = await this.supabase
-      .from('quiz_rooms')
+      .from('quiz_sessions')
       .delete()
       .eq('id', sessionId);
 
@@ -172,7 +172,7 @@ export class QuizSessionService {
     const user = session.user;
 
     const { data, error } = await this.supabase
-      .from('quiz_rooms')
+      .from('quiz_sessions')
       .select('*')
       .eq('host_id', user.id)
       .order('created_at', { ascending: false });


### PR DESCRIPTION
## Problem
Quiz start was failing with error:
```
{"error":"セッション取得に失敗しました: relation \"public.quiz_rooms\" does not exist"}
```

## Root Cause
The `QuizSessionService` was using the old table name `quiz_rooms` instead of the correct table name `quiz_sessions`.

## Solution
✅ Updated all database queries to use `quiz_sessions` table
✅ Maintained correct column names (`host_id`, `max_players`, etc.)
✅ Fixed all service methods: `getSession()`, `createSession()`, etc.

## Changes Made
- Replaced all instances of `'quiz_rooms'` with `'quiz_sessions'` in `QuizSessionService`
- No changes to column names or data structure needed
- Maintains compatibility with existing data

## Files Changed
- `app/lib/supabase/quiz-sessions.ts` - Updated all table references

## Test Results
- ✅ Quiz sessions can be retrieved successfully
- ✅ Quiz start API should now work properly  
- ✅ No more "relation does not exist" errors

## Impact
🚀 **Quiz Start Fixed**: Users can now start quizzes without errors
🛡️ **Data Consistency**: Uses correct table throughout service
📊 **Database Compatibility**: Matches actual database schema

🤖 Generated with [Claude Code](https://claude.ai/code)