### PR TITLE
Fix question generation API errors

### DIFF
--- a/app/api/quiz/questions/generate/route.ts
+++ b/app/api/quiz/questions/generate/route.ts
@@ -1,7 +1,7 @@
 // 問題生成API
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/app/lib/supabase/client';
+import { createClient } from '@/app/lib/supabase/server';
 import { VideoProcessor } from '@/app/lib/utils/video-processor';
 import type { VideoInfo } from '@/app/lib/utils/video-processor';
 
@@ -17,11 +17,11 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const supabase = createClient();
+    const supabase = await createClient();
 
     // セッション情報取得
     const { data: session, error: sessionError } = await supabase
-      .from('quiz_rooms')
+      .from('quiz_sessions')
       .select('*, playlists(*)')
       .eq('id', sessionId)
       .single();


### PR DESCRIPTION
## Problem
Question generation was failing with errors:
- `{"error":"セッションが見つかりません"}`
- `POST /api/quiz/questions/generate 404 (Not Found)`

## Root Cause
Two issues in the question generation API:

1. **Wrong Table Name**: API was querying `quiz_rooms` instead of `quiz_sessions`
2. **Wrong Authentication**: Using client-side Supabase instead of server-side

## Solution
✅ **Correct Table**: Changed from `quiz_rooms` to `quiz_sessions`
✅ **Server Auth**: Use `@/app/lib/supabase/server` for API authentication
✅ **Proper Async**: Await server client initialization

## Changes Made

### Table Name Fix
```typescript
// Before
const { data: session } = await supabase
  .from('quiz_rooms')

// After  
const { data: session } = await supabase
  .from('quiz_sessions')
```

### Authentication Fix
```typescript
// Before
import { createClient } from '@/app/lib/supabase/client';
const supabase = createClient();

// After
import { createClient } from '@/app/lib/supabase/server';
const supabase = await createClient();
```

## Files Changed
- `app/api/quiz/questions/generate/route.ts` - Fixed table name and auth

## Test Results
- ✅ Question generation API can find quiz sessions
- ✅ Server-side authentication works properly
- ✅ Host can generate questions from playlists

## Benefits
🔍 **Session Found**: API can locate quiz sessions in correct table
🔐 **Proper Auth**: Server-side authentication for API security
🎯 **Question Generation**: Host can now generate questions successfully
🚀 **Complete Flow**: Question generation → Quiz start works end-to-end

🤖 Generated with [Claude Code](https://claude.ai/code)