### PR TITLE
Debug: Add logging for video_id NULL issue

### DIFF
--- a/app/api/quiz/questions/generate/route.ts
+++ b/app/api/quiz/questions/generate/route.ts
@@ -68,13 +68,26 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // デバッグ: 取得した動画データを確認
+    console.log('Retrieved playlist videos:', playlistVideos);
+
     // 動画情報を VideoInfo 形式に変換
-    const videoInfos: VideoInfo[] = playlistVideos.map(video => ({
-      id: video.video_id,
-      title: video.title,
-      duration: video.duration || 300, // デフォルト5分
-      thumbnail: video.thumbnail_url || VideoProcessor.getThumbnailUrl(video.video_id)
-    }));
+    const videoInfos: VideoInfo[] = playlistVideos.map(video => {
+      console.log('Processing video:', {
+        video_id: video.video_id,
+        title: video.title,
+        duration: video.duration
+      });
+      
+      return {
+        id: video.video_id,
+        title: video.title,
+        duration: video.duration || 300, // デフォルト5分
+        thumbnail: video.thumbnail_url || VideoProcessor.getThumbnailUrl(video.video_id)
+      };
+    });
+    
+    console.log('Converted video infos:', videoInfos);
 
     // 問題データ生成
     const questionData = await VideoProcessor.generateQuestionsFromPlaylist(


### PR DESCRIPTION
## Problem
Question generation is failing with:
```
null value in column "video_id" violates not-null constraint
```

## Debug Strategy
Added comprehensive logging to identify where `video_id` becomes NULL:

1. **Database Query Results**: Log raw playlist videos from database
2. **Individual Processing**: Log each video as it's processed
3. **Final Conversion**: Log the converted VideoInfo objects

## Expected Findings
This will help us determine if:
- `youtube_videos.video_id` column is NULL in database
- Video processing logic has issues
- Data conversion is failing

## Next Steps
After deployment, test question generation and check server logs to identify:
- What data is returned from `youtube_videos` table
- Which step causes `video_id` to become NULL
- Appropriate fix based on the root cause

This is a diagnostic PR to gather information for the proper fix.

🤖 Generated with [Claude Code](https://claude.ai/code)