### PR TITLE
Fix NULL video_id handling in question generation

### DIFF
--- a/app/api/quiz/questions/generate/route.ts
+++ b/app/api/quiz/questions/generate/route.ts
@@ -71,8 +71,20 @@ export async function POST(request: NextRequest) {
     // デバッグ: 取得した動画データを確認
     console.log('Retrieved playlist videos:', playlistVideos);
 
+    // NULL video_id の動画をフィルタリング
+    const validVideos = playlistVideos.filter(video => video.video_id !== null && video.video_id !== undefined);
+    
+    if (validVideos.length === 0) {
+      return NextResponse.json(
+        { error: 'プレイリストに有効な動画がありません。動画IDがnullの動画は問題生成に使用できません。' },
+        { status: 400 }
+      );
+    }
+
+    console.log(`Filtered ${validVideos.length} valid videos out of ${playlistVideos.length} total videos`);
+
     // 動画情報を VideoInfo 形式に変換
-    const videoInfos: VideoInfo[] = playlistVideos.map(video => {
+    const videoInfos: VideoInfo[] = validVideos.map(video => {
       console.log('Processing video:', {
         video_id: video.video_id,
         title: video.title,


### PR DESCRIPTION
## Summary
- Fix handling of NULL video_id values in question generation API
- Filter out videos with NULL video_id before processing to prevent database constraint violations
- Add informative error message when no valid videos are available

## Problem
The `youtube_videos` table contains many records with NULL `video_id` values, causing question generation to fail with:
```
null value in column 'video_id' violates not-null constraint
```

## Solution
- Filter videos to only include those with valid (non-null) `video_id` values
- Provide clear error message if no valid videos remain after filtering
- Add debug logging to track filtering results

## Test plan
- [ ] Test question generation with playlists containing NULL video_id records
- [ ] Verify error message displays when all videos have NULL video_id
- [ ] Confirm successful generation when valid videos exist

🤖 Generated with [Claude Code](https://claude.ai/code)